### PR TITLE
Trigger a build of the new SNAPSHOT version after release

### DIFF
--- a/release/action.yml
+++ b/release/action.yml
@@ -60,3 +60,20 @@ runs:
         add: ./gradle.properties
         message: 'Updated to next SNAPSHOT version'
         default_author: github_actions
+
+    # The "Updated to next SNAPSHOT version" commit above is pushed with the
+    # GITHUB_TOKEN, which by design does NOT trigger `on: push`. Dispatch the
+    # calling workflow so the new SNAPSHOT is built and published. The workflow
+    # must declare `workflow_dispatch` (present on the default branch) and the
+    # token needs `actions: write`. Best-effort: the release already succeeded,
+    # so a failed dispatch only emits a warning.
+    - name: Trigger build of new snapshot version
+      if: steps.publish_vars.outputs.release == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        workflow="${GITHUB_WORKFLOW_REF%%@*}"   # owner/repo/.github/workflows/x.yml
+        workflow="${workflow##*/}"               # x.yml
+        gh workflow run "$workflow" --ref "$GITHUB_REF_NAME" \
+          || echo "::warning title=SNAPSHOT build not dispatched::Could not dispatch a build for the new SNAPSHOT version (the calling workflow may be missing 'workflow_dispatch' on the default branch, or Actions cannot run it). The release itself succeeded."


### PR DESCRIPTION
## Why
The `release` action pushes an "Updated to next SNAPSHOT version" commit using `GITHUB_TOKEN`. By [GitHub's design](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow), events made with `GITHUB_TOKEN` (except `workflow_dispatch`/`repository_dispatch`) do not start new workflow runs — so that bump never builds or publishes the new SNAPSHOT.

## What
Adds a `Trigger build of new snapshot version` step, gated on `release == 'true'` (same as the bump push). It re-dispatches the **calling** workflow via `workflow_dispatch`, derived from `GITHUB_WORKFLOW_REF`, on `GITHUB_REF_NAME` (the release branch, now at the bumped commit). The dispatched run builds a `-SNAPSHOT`, so `publish_vars` returns `release=false` and this action does not re-run — no recursion.

## Consumer requirements
- The workflow must declare `workflow_dispatch` in `on:`, present on the **default branch** (GitHub only accepts dispatches for workflows defined there).
- The token must have `actions: write`.

If a consumer hasn't met these, the step is best-effort: it emits a `::warning::` and the release stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
